### PR TITLE
Fix PHP 7 Compatibility issue.

### DIFF
--- a/Net/Wifi.php
+++ b/Net/Wifi.php
@@ -323,7 +323,7 @@ class Net_Wifi
                 //add new cell
                 $arCells[$nCurrentCell]       = new Net_Wifi_Cell();
                 $arCells[$nCurrentCell]->cell = $nCell;
-                $arCells[$nCurrentCell]->ies = "";
+                $arCells[$nCurrentCell]->ies = array();
                 $arCells[$nCurrentCell]->wpa = false;
                 $arCells[$nCurrentCell]->wpa2 = false;
                 $arCells[$nCurrentCell]->wpa_group_cipher = array();


### PR DESCRIPTION
When using Net_Wifi via PHP 7, this fatal error is caught:
"PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /usr/share/php/Net/Wifi.php:375"

I fixed this by changing the ies property to be an array.

@cweiske, I know you did "abandon" this package, but as you're still active on other PEAR packages, I thought I'd assign this to you, if you wouldn't mind having a quick look at it please?
